### PR TITLE
Improve hashing performance

### DIFF
--- a/src/python/py27hash/hash.py
+++ b/src/python/py27hash/hash.py
@@ -142,10 +142,9 @@ class Hash(object):
 
         x = Hash.ordinal(value[0]) << 7
         for c in value:
-            x = (1000003 * x) ^ Hash.ordinal(c)
+            x = ((1000003 * x) ^ Hash.ordinal(c)) & 0xffffffffffffffff
 
         x ^= length
-        x &= 0xffffffffffffffff
         if x == -1:
             x = -2
 


### PR DESCRIPTION
The value of 'x' can grow very large here with each successive multiplication. Since we are truncating back to 64 bits in the end here, there is no point to allowing this number to grow larger than 64 bits, and can be truncated back after every iteration of the loop - and yield the same result.