### PR TITLE
Support testing on 32-bit platforms

### DIFF
--- a/test/python/test/testdict.py
+++ b/test/python/test/testdict.py
@@ -2,10 +2,14 @@
 
 import os
 import pickle
+import sys
 import unittest
 
 from py27hash.dict import Dict
 from py27hash.hash import hash27
+
+is_32bit = sys.maxsize < 2**32
+
 
 class TestDict(unittest.TestCase):
     def test_small(self):
@@ -15,8 +19,9 @@ class TestDict(unittest.TestCase):
             d[str(x)] = x
 
         # Test key and value
-        self.assertEqual(hash27("".join(d)), 6636034109572507556)
-        self.assertEqual(hash27("".join([str(x) for x in d.values()])), 6636034109572507556)
+        expected = 175237028 if is_32bit else 6636034109572507556
+        self.assertEqual(hash27("".join(d)), expected)
+        self.assertEqual(hash27("".join([str(x) for x in d.values()])), expected)
 
     @unittest.skipIf(os.environ.get("SKIPSLOW", "skipslow"), "Slow tests skipped via skipslow argument")
     def test_large(self):
@@ -26,8 +31,9 @@ class TestDict(unittest.TestCase):
             d[str(x)] = x
 
         # Test key and value
-        self.assertEqual(hash27("".join(d)), -35326655653467556)
-        self.assertEqual(hash27("".join([str(x) for x in d.values()])), -35326655653467556)
+        expected = -1791340678 if is_32bit else -35326655653467556
+        self.assertEqual(hash27("".join(d)), expected)
+        self.assertEqual(hash27("".join([str(x) for x in d.values()])), expected)
 
     def test_keys(self):
         d = Dict()
@@ -36,7 +42,8 @@ class TestDict(unittest.TestCase):
         d[30] = 3
         d["test1234"] = 4
 
-        self.assertEqual(hash27("".join([str(k) for k in d])), 7766555225202364718)
+        expected = 245633326 if is_32bit else 7766555225202364718
+        self.assertEqual(hash27("".join([str(k) for k in d])), expected)
 
     def test_merge(self):
         # Build list of (key, value) pairs to preserve insertion ordering
@@ -52,8 +59,9 @@ class TestDict(unittest.TestCase):
         m = Dict(d)
         m.update(e)
 
-        self.assertEqual(hash27("".join(m)), -5846033856052761336)
-        self.assertEqual(hash27("".join([str(x) for x in m.values()])), -5846033856052761336)
+        expected = 2031185160 if is_32bit else -5846033856052761336
+        self.assertEqual(hash27("".join(m)), expected)
+        self.assertEqual(hash27("".join([str(x) for x in m.values()])), expected)
 
     def test_update(self):
         d = Dict()
@@ -64,7 +72,8 @@ class TestDict(unittest.TestCase):
         d["255"] = "abc"
         d["100"] = "123"
 
-        self.assertEqual(hash27("".join(d)), -7925872281736336380)
+        expected = 536718340 if is_32bit else -7925872281736336380
+        self.assertEqual(hash27("".join(d)), expected)
 
     def test_delete(self):
         d = Dict()
@@ -75,7 +84,8 @@ class TestDict(unittest.TestCase):
         del d["53"]
         d.pop("155")
 
-        self.assertEqual(hash27("".join(d)), -8652364590473687932)
+        expected = 1168493700 if is_32bit else -8652364590473687932
+        self.assertEqual(hash27("".join(d)), expected)
 
     def test_pickle(self):
         d = Dict()
@@ -89,7 +99,8 @@ class TestDict(unittest.TestCase):
         data = pickle.dumps(d)
         d = pickle.loads(data)
 
-        self.assertEqual(hash27("".join(d)), 6818550152093286356)
+        expected = -1296777260 if is_32bit else 6818550152093286356
+        self.assertEqual(hash27("".join(d)), expected)
 
     def test_clear(self):
         d = Dict()
@@ -102,7 +113,8 @@ class TestDict(unittest.TestCase):
         for x in range(1000, 1500):
             d[str(x)] = x
 
-        self.assertEqual(hash27("".join(d)), -1473514505880218088)
+        expected = 698340888 if is_32bit else -1473514505880218088
+        self.assertEqual(hash27("".join(d)), expected)
 
     def test_copy(self):
         d = Dict()
@@ -112,7 +124,8 @@ class TestDict(unittest.TestCase):
 
         d = d.copy()
 
-        self.assertEqual(hash27("".join(d)), 1141231293364439680)
+        expected = -1829309066 if is_32bit else 1141231293364439680
+        self.assertEqual(hash27("".join(d)), expected)
 
     def test_fromkeys(self):
         s = []
@@ -122,7 +135,8 @@ class TestDict(unittest.TestCase):
 
         d = Dict.fromkeys(s)
 
-        self.assertEqual(hash27("".join(d)), -7925872281736336380)
+        expected = 536718340 if is_32bit else -7925872281736336380
+        self.assertEqual(hash27("".join(d)), expected)
 
     def test_pop(self):
         d = Dict()
@@ -140,4 +154,5 @@ class TestDict(unittest.TestCase):
 
         d.popitem()
 
-        self.assertEqual(hash27("".join(d)), -434207861779954688)
+        expected = 267158528 if is_32bit else -434207861779954688
+        self.assertEqual(hash27("".join(d)), expected)

--- a/test/python/test/testhash.py
+++ b/test/python/test/testhash.py
@@ -1,24 +1,34 @@
 # pylint: disable = C0111,W0622,E0401
 
+import sys
 import unittest
 
 from py27hash.hash import hash27
 
+is_32bit = sys.maxsize < 2**32
+
+
 class TestHash(unittest.TestCase):
     def test_thash1(self):
-        self.assertEqual(hash27(("abc", 1)), -6007909421085996277)
+        expected = 2037533451 if is_32bit else -6007909421085996277
+        self.assertEqual(hash27(("abc", 1)), expected)
 
     def test_thash2(self):
-        self.assertEqual(hash27((3.5, 5.83)), 8767369050595774471)
+        expected = 864276487 if is_32bit else 8767369050595774471
+        self.assertEqual(hash27((3.5, 5.83)), expected)
 
     def test_fhash(self):
-        self.assertEqual(hash27(1235.333333), 3408413012)
+        expected = -886554284 if is_32bit else 3408413012
+        self.assertEqual(hash27(1235.333333), expected)
 
     def test_ihash(self):
-        self.assertEqual(hash27(15344), 15344)
+        expected = 15344
+        self.assertEqual(hash27(15344), expected)
 
     def test_shash(self):
-        self.assertEqual(hash27("test1234"), 1724133767363937712)
+        expected = -855915088 if is_32bit else 1724133767363937712
+        self.assertEqual(hash27("test1234"), expected)
 
     def test_bhash(self):
-        self.assertEqual(hash27("test1234".encode("utf-8")), 1724133767363937712)
+        expected = -855915088 if is_32bit else 1724133767363937712
+        self.assertEqual(hash27("test1234".encode("utf-8")), expected)

--- a/test/python/test/testset.py
+++ b/test/python/test/testset.py
@@ -2,10 +2,14 @@
 
 import pickle
 import os
+import sys
 import unittest
 
 from py27hash.hash import hash27
 from py27hash.set import Set
+
+is_32bit = sys.maxsize < 2**32
+
 
 class TestSet(unittest.TestCase):
     def test_small(self):
@@ -14,7 +18,8 @@ class TestSet(unittest.TestCase):
         for x in range(15):
             d.add(str(x))
 
-        self.assertEqual(hash27("".join(d)), 6636034109572507556)
+        expected = 175237028 if is_32bit else 6636034109572507556
+        self.assertEqual(hash27("".join(d)), expected)
 
     @unittest.skipIf(os.environ.get("SKIPSLOW", "skipslow"), "Slow tests skipped via skipslow argument")
     def test_large(self):
@@ -23,7 +28,8 @@ class TestSet(unittest.TestCase):
         for x in range(60000):
             d.add(str(x))
 
-        self.assertEqual(hash27("".join(d)), -35326655653467556)
+        expected = -1791340678 if is_32bit else -35326655653467556
+        self.assertEqual(hash27("".join(d)), expected)
 
     def test_values(self):
         d = Set()
@@ -32,7 +38,8 @@ class TestSet(unittest.TestCase):
         d.add(30)
         d.add("test1234")
 
-        self.assertEqual(hash27("".join([str(k) for k in d])), 7766555225202364718)
+        expected = 245633326 if is_32bit else 7766555225202364718
+        self.assertEqual(hash27("".join([str(k) for k in d])), expected)
 
     def test_merge(self):
         # Build list of (key, value) pairs to preserve insertion ordering
@@ -48,7 +55,8 @@ class TestSet(unittest.TestCase):
         m = Set(d)
         m.update(e)
 
-        self.assertEqual(hash27("".join(m)), -5846033856052761336)
+        expected = 2031185160 if is_32bit else -5846033856052761336
+        self.assertEqual(hash27("".join(m)), expected)
 
     def test_delete(self):
         d = Set()
@@ -59,7 +67,8 @@ class TestSet(unittest.TestCase):
         d.remove("53")
         d.discard("155")
 
-        self.assertEqual(hash27("".join(d)), -8652364590473687932)
+        expected = 1168493700 if is_32bit else -8652364590473687932
+        self.assertEqual(hash27("".join(d)), expected)
 
     def test_pickle(self):
         d = Set()
@@ -73,7 +82,8 @@ class TestSet(unittest.TestCase):
         data = pickle.dumps(d)
         d = pickle.loads(data)
 
-        self.assertEqual(hash27("".join(d)), 6818550152093286356)
+        expected = -1296777260 if is_32bit else 6818550152093286356
+        self.assertEqual(hash27("".join(d)), expected)
 
     def test_clear(self):
         d = Set()
@@ -86,7 +96,8 @@ class TestSet(unittest.TestCase):
         for x in range(1000, 1500):
             d.add(str(x))
 
-        self.assertEqual(hash27("".join(d)), -1473514505880218088)
+        expected = 698340888 if is_32bit else -1473514505880218088
+        self.assertEqual(hash27("".join(d)), expected)
 
     def test_copy(self):
         d = Set()
@@ -96,7 +107,8 @@ class TestSet(unittest.TestCase):
 
         d = d.copy()
 
-        self.assertEqual(hash27("".join(d)), 1141231293364439680)
+        expected = -1829309066 if is_32bit else 1141231293364439680
+        self.assertEqual(hash27("".join(d)), expected)
 
     def test_pop(self):
         d = Set()
@@ -106,4 +118,5 @@ class TestSet(unittest.TestCase):
 
         d.pop()
 
-        self.assertEqual(hash27("".join(d)), -434207861779954688)
+        expected = 267158528 if is_32bit else -434207861779954688
+        self.assertEqual(hash27("".join(d)), expected)


### PR DESCRIPTION
Add expected hash values from 32-bit Python 2.7 so that the tests can be executed on 32-bit platforms, too.