### PR TITLE
Fix hash == -1 checks, and improve string hashing performance.

### DIFF
--- a/src/python/py27hash/hash.py
+++ b/src/python/py27hash/hash.py
@@ -77,11 +77,13 @@ class Hash(object):
 
         x += 97531
 
+        # Convert to C type
+        x = ctypes.c_long(x).value
+
         if x == -1:
             x = -2
 
-        # Convert to C type
-        return ctypes.c_long(x).value
+        return x
 
     @staticmethod
     def fhash(value):
@@ -114,11 +116,14 @@ class Hash(object):
         v = (v - float(hipart)) * 2147483648.0
 
         x = hipart + int(v) + (e << 15)
+
+        # Convert to C long type
+        x = ctypes.c_long(x).value
+
         if x == -1:
             x = -2
 
-        # Convert to C long type
-        return ctypes.c_long(x).value
+        return x
 
     @staticmethod
     def shash(value):
@@ -146,11 +151,14 @@ class Hash(object):
 
         x ^= length
         x &= 0xffffffffffffffff
+
+        # Convert to C long type
+        x = ctypes.c_long(x).value
+
         if x == -1:
             x = -2
 
-        # Convert to C long type
-        return ctypes.c_long(x).value
+        return x
 
     @staticmethod
     def ordinal(value):
@@ -165,4 +173,3 @@ class Hash(object):
         """
 
         return value if isinstance(value, int) else ord(value)
- 

--- a/src/python/py27hash/hash.py
+++ b/src/python/py27hash/hash.py
@@ -145,12 +145,12 @@ class Hash(object):
         if length == 0:
             return 0
 
-        x = Hash.ordinal(value[0]) << 7
+        mask = 0xffffffffffffffff
+        x = (Hash.ordinal(value[0]) << 7) & mask
         for c in value:
-            x = (1000003 * x) ^ Hash.ordinal(c)
+            x = (1000003 * x) & mask ^ Hash.ordinal(c)
 
-        x ^= length
-        x &= 0xffffffffffffffff
+        x ^= length & mask
 
         # Convert to C long type
         x = ctypes.c_long(x).value


### PR DESCRIPTION
Check for hash value -1 *after* conversion via `ctypes.c_long`. See the commit message for detailed justification. Unfortunately, it’s fussy at best to find test cases for this.

Mask after each widening operation in string hashing to keep the state from growing without bound. As a result, in a quick benchmark, overall test suite runtime is decreased by about two thirds. This change also means that large string hashing runtime, while still not fast, should at least be asymptotically linear with string length.